### PR TITLE
Allow configuration options when connecting to a network

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,8 @@ mod wifi;
 mod ssid;
 
 pub use manager::{Connectivity, NetworkManager};
-pub use connection::{Connection, ConnectionSettings, ConnectionState};
+pub use connection::{Connection, ConnectionSettings, ConnectionState,
+     ConnectionConfigBuilder};
 pub use device::{Device, DeviceState, DeviceType};
 pub use wifi::{AccessPoint, AccessPointCredentials, Security};
 pub use service::ServiceState;

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -4,7 +4,8 @@ use std::net::Ipv4Addr;
 use errors::*;
 use dbus_nm::DBusNetworkManager;
 
-use connection::{connect_to_access_point, create_hotspot, Connection, ConnectionState};
+use connection::{connect_to_access_point, connect_to_access_point_with_config, 
+    create_hotspot, Connection, ConnectionState, ConnectionConfig};
 use device::{Device, PathGetter};
 use ssid::{AsSsidSlice, Ssid, SsidSlice};
 
@@ -63,6 +64,22 @@ impl<'a> WiFiDevice<'a> {
             access_point,
             credentials,
         )
+    }
+
+    pub fn connect_with_config(
+        &self,
+        access_point: &AccessPoint,
+        credentials: &AccessPointCredentials,
+        config: &ConnectionConfig,
+    ) -> Result<(Connection, ConnectionState)> {
+        connect_to_access_point_with_config(
+            &self.dbus_manager,
+            self.device.path(),
+            access_point,
+            credentials,
+            config
+        )
+
     }
 
     pub fn create_hotspot<T>(


### PR DESCRIPTION
This PR adds the ability to configure the network upon connecting. Currently, the only possible connection configuration is the ipv4 dns settings. However, I set it up so that it's easy to add new configuration options.

This was useful for us with `wifi-connect` because we wanted to configure the dns servers to use `1.1.1.1` on connection creation.