### PR TITLE
Add missing NMDeviceTypes

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -178,6 +178,15 @@ impl From<i64> for DeviceType {
             20 => DeviceType::Veth,
             21 => DeviceType::Macsec,
             22 => DeviceType::Dummy,
+            23 => DeviceType::PPP,
+            24 => DeviceType::OVS_INTERFACE,
+            25 => DeviceType::OVS_PORT,
+            26 => DeviceType::OVS_BRIDGE,
+            27 => DeviceType::WPAN,
+            28 => DeviceType::6LOWPAN,
+            29 => DeviceType::WIREGUARD,
+            30 => DeviceType::WIFI_P2P,
+            30 => DeviceType::VRF,
             _ => {
                 warn!("Undefined device type: {}", device_type);
                 DeviceType::Unknown


### PR DESCRIPTION
Change-type: minor

Adds missing Device Types as per: https://developer-old.gnome.org/NetworkManager/stable/nm-dbus-types.html#NMDeviceType

Networkmanager 1.16 introduce P2P which is now visible on the latest balenaOS. Without this device type added, users can encounter errors. 

https://jel.ly.fish/support-thread-1-0-0-front-cnv-dqbg2z1

Untested