### PR TITLE
Add missing NMDeviceTypes

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -130,6 +130,15 @@ pub enum DeviceType {
     Veth,
     Macsec,
     Dummy,
+    Ppp,
+    OvsInterface,
+    OvsPort,
+    OvsBridge,
+    Wpan,
+    Lowpan,
+    Wireguard,
+    WifiP2p,
+    Vrf,
 }
 
 impl From<i64> for DeviceType {
@@ -158,6 +167,15 @@ impl From<i64> for DeviceType {
             20 => DeviceType::Veth,
             21 => DeviceType::Macsec,
             22 => DeviceType::Dummy,
+            23 => DeviceType::Ppp,
+            24 => DeviceType::OvsInterface,
+            25 => DeviceType::OvsPort,
+            26 => DeviceType::OvsBridge,
+            27 => DeviceType::Wpan,
+            28 => DeviceType::Lowpan,
+            29 => DeviceType::Wireguard,
+            30 => DeviceType::WifiP2p,
+            31 => DeviceType::Vrf,
             _ => {
                 warn!("Undefined device type: {}", device_type);
                 DeviceType::Unknown


### PR DESCRIPTION
Change-type: minor

Adds missing Device Types as per: https://developer-old.gnome.org/NetworkManager/stable/nm-dbus-types.html#NMDeviceType

Networkmanager 1.16 introduces P2P which is now visible on the latest balenaOS. Without this device type added, users can encounter errors.

https://jel.ly.fish/support-thread-1-0-0-front-cnv-dqbg2z1

Untested

Error:

```
[network_manager::device:WARN] Undefined device type: 30
WiFi device: wlp0s20f3
[network_manager::dbus_api:ERROR] Get org.freedesktop.NetworkManager.AccessPoint::RsnFlags property failed on /org/freedesktop/NetworkManager/AccessPoint/103: wrong property type
Error: Getting access points failed
caused by: D-Bus failure: Get org.freedesktop.NetworkManager.AccessPoint::RsnFlags property failed on /org/freedesktop/NetworkManager/AccessPoint/103: wrong property type
```

Relates to `Undefined device type: 30`, whereas AccessPoint flags related to:

https://github.com/balena-os/wifi-connect/issues/416
https://github.com/balena-io-modules/network-manager/pull/137

https://jel.ly.fish/support-thread-1-0-0-front-cnv-dqbg2z1