### PR TITLE
wpa3 support

### DIFF
--- a/src/dbus_nm.rs
+++ b/src/dbus_nm.rs
@@ -253,6 +253,18 @@ impl DBusNetworkManager {
                 settings.insert("802-11-wireless-security".to_string(), security_settings);
                 settings.insert("802-1x".to_string(), eap);
             }
+            AccessPointCredentials::Sae { ref passphrase } => {
+                let mut security_settings: VariantMap = HashMap::new();
+
+                add_str(&mut security_settings, "key-mgmt", "sae");
+                add_str(
+                    &mut security_settings,
+                    "psk",
+                    verify_ascii_password(passphrase)?,
+                );
+
+                settings.insert("802-11-wireless-security".to_string(), security_settings);
+            }
             AccessPointCredentials::None => {}
         };
 

--- a/src/wifi.rs
+++ b/src/wifi.rs
@@ -94,6 +94,7 @@ bitflags! {
         const WPA          = 0b0000_0010;
         const WPA2         = 0b0000_0100;
         const ENTERPRISE   = 0b0000_1000;
+        const WPA3         = 0b0001_0000;
     }
 }
 
@@ -108,6 +109,9 @@ pub enum AccessPointCredentials {
     },
     Enterprise {
         identity: String,
+        passphrase: String,
+    },
+    Sae {
         passphrase: String,
     },
 }
@@ -213,6 +217,9 @@ fn get_access_point_security(manager: &DBusNetworkManager, path: &str) -> Result
 
     if rsn_flags != NM80211ApSecurityFlags::AP_SEC_NONE {
         security |= Security::WPA2;
+    }
+    if rsn_flags.contains(NM80211ApSecurityFlags::AP_SEC_KEY_MGMT_SAE) {
+        security |= Security::WPA3;
     }
 
     if wpa_flags.contains(NM80211ApSecurityFlags::AP_SEC_KEY_MGMT_802_1X)


### PR DESCRIPTION
This allows me to connect to WPA3 networks that use SAE authentication.

Tested on Debian Bullseye (network-manager=1.30.6-1+deb11u1), also works with network-manager=1.42.4-1~bpo11+1 from bullseye-backports.